### PR TITLE
P2-3637, added additional check in validation function and more test cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ class CompassDigitalId
 		{
 			if(!id) return false;
 			if(!id.length || id.length < 13) return false; // IDs never are smaller than 13 chars.
-
+			if(Number.isFinite(Number(id))) return false;
 			var hex = hashids.decodeHex(id);
 			if(!hex || Array.isArray(hex)) return false;
 			return true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,9 +1138,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.362",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.362.tgz",
-      "integrity": "sha512-xdU5VCoZyMPMOWtCaMgbr48OwWZHrMLbGnAOlEqibXiIGsb4kiCGWEHK5NOghcVLdBVIbr/BW+yuKxVuGTtzEg==",
+      "version": "1.3.364",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.364.tgz",
+      "integrity": "sha512-V6hyxQ9jzt6Jy6w8tAv4HHKhIaVS6psG/gmwtQ+2+itdkWMHJLHJ4m1sFep/fWkdKvfJcPXuywfnECRzfNa7gw==",
       "dev": true
     },
     "es6-object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Compass Digital IDs",
   "main": "dist/index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -318,8 +318,8 @@ describe("Compass Digital IDs", function()
             type: "item",
             id: "abc123"
 		});
-
 		const cdl_class = compassdigitalid.CompassDigitalId;
+
 		cdl_class.valid(new_id).should.eql(true);
 		cdl_class.valid(undefined).should.eql(false);
 		cdl_class.valid(123).should.eql(false);
@@ -333,6 +333,23 @@ describe("Compass Digital IDs", function()
 		done();
 
 	});
+
+	it("should check validity of id correctly", function(done)
+	{
+		const cdl_class = compassdigitalid.CompassDigitalId;
+		for(let i = 0; i < 10000; i++)
+		{
+			const now = Date.now();
+			cdl_class.valid(
+					compassdigitalid("item", "test", "test", Math.random().toString().replace(".", ""))
+			).should.eql(true);
+			cdl_class.valid(compassdigitalid("item", "test", "test", now)).should.eql(true);
+			cdl_class.valid(now.toString()).should.eql(false);
+		}
+		done();
+
+	});
+
 	it("should decode undefined to undefined", function(done)
 	{
 		should.not.exist(compassdigitalid(undefined));

--- a/test/test.js
+++ b/test/test.js
@@ -325,6 +325,10 @@ describe("Compass Digital IDs", function()
 		cdl_class.valid(123).should.eql(false);
 		cdl_class.valid("abc123").should.eql(false);
 		cdl_class.valid("12323232234e1123").should.eql(false);
+		cdl_class.valid(Date.now().toString()).should.eql(false);
+		cdl_class.valid('0408112729134111e177208782105365').should.eql(false);
+		cdl_class.valid('15829942683315').should.eql(false);
+		cdl_class.valid(15829942683315).should.eql(false);
 		cdl_class.valid("12323232").should.eql(false);
 		done();
 


### PR DESCRIPTION
The reason for this PR is that after changing the version of HashIds, in rare cases `valid(Date.now().toString() ) `returns true, which is not correct.

We could've reverted HashIds version and that would solve it, but there is a more than 2x performance improvement in encoding/decoding, so I suggest to keep it.