### PR TITLE
AR-6, improve type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,10 @@
 declare namespace cdl {
+	export type EncodedID = string;
 	export interface DecodedID {
 		service: string;
 		provider: string;
 		type: string;
-		id: string;
+		id?: string;
 	}
 }
 
@@ -26,7 +27,7 @@ declare module '@compassdigital/id' {
 		id: string
 	): string;
 	function ID(decoded: cdl.DecodedID): string;
-	function ID(encoded: string): cdl.DecodedID;
+	function ID(encoded: string): cdl.DecodedID | undefined;
 	function ID(encoded: string | undefined): cdl.DecodedID | undefined;
 	function ID(decoded: cdl.DecodedID | undefined): string | undefined;
 	export = ID;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "Compass Digital IDs",
   "main": "dist/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* Re-add previously removed string alias for encoded ids.
* Make ID decoding possibly return `undefined`.
* Bump version to `3.2.0`