### PR TITLE
AR-6, Use ambient module for types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
-declare namespace cdl {
+
+declare module '@compassdigital/id/interface' {
 	export type EncodedID = string;
 	export interface DecodedID {
 		service: string;
@@ -9,6 +10,8 @@ declare namespace cdl {
 }
 
 declare module '@compassdigital/id' {
+
+	import { DecodedID } from '@compassdigital/id/interface';
 
 	/**
 	 * ID is a utility function which both encodes and decodes CDL ids using a
@@ -26,9 +29,9 @@ declare module '@compassdigital/id' {
 		type: string,
 		id: string
 	): string;
-	function ID(decoded: cdl.DecodedID): string;
-	function ID(encoded: string): cdl.DecodedID | undefined;
-	function ID(encoded: string | undefined): cdl.DecodedID | undefined;
-	function ID(decoded: cdl.DecodedID | undefined): string | undefined;
+	function ID(decoded: DecodedID): string;
+	function ID(encoded: string): DecodedID | undefined;
+	function ID(encoded: string | undefined): DecodedID | undefined;
+	function ID(decoded: DecodedID | undefined): string | undefined;
 	export = ID;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Compass Digital IDs",
   "main": "dist/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I originally introduced the `cdl` namespace because nothing else could be exported from the `@compassdigital/id` module (because it assigns to `export`). I now realize that we could have just added an additional ambient module which only contains types. This is much cleaner than introducing a namespace as a global.

``` typescript

declare module '@compassdigital/id/interface' {
	export type EncodedID = string;
	export interface DecodedID {
		service: string;
		provider: string;
		type: string;
		id?: string;
	}
}

declare module '@compassdigital/id' {

	import { DecodedID } from '@compassdigital/id/interface';

	/**
	 * ID is a utility function which both encodes and decodes CDL ids using a
	 * bespoke encoding scheme.
	 *
	 * - If a string is provided, it will be decoded to an id object.
	 * - If an id object is provided, it will be encoded to a string.
	 * - If a falsy value is provided, undefined will be returned.
	 * - If 4 string parameters are provided, they will be used to construct an
	 *   id object which will then be encoded to a string.
	 */
	function ID(
		service: string,
		provider: string,
		type: string,
		id: string
	): string;
	function ID(decoded: DecodedID): string;
	function ID(encoded: string): DecodedID | undefined;
	function ID(encoded: string | undefined): DecodedID | undefined;
	function ID(decoded: DecodedID | undefined): string | undefined;
	export = ID;
}
```