### PR TITLE
Prevent undefined id property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module '@compassdigital/id/interface' {
 		service: string;
 		provider: string;
 		type: string;
-		id?: string;
+		id: string;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class CompassDigitalId
 
 			if(parsed.length >= 3)
 			{
-				var id = parsed[3] ? joined.substring(parsed[0].length + parsed[1].length + parsed[2].length + 3) : parsed[3];
+				var id = parsed[3] ? joined.substring(parsed[0].length + parsed[1].length + parsed[2].length + 3) : "";
 
 				var json = {
 					service: parsed[0],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.1.5",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compassdigital/id",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Compass Digital IDs",
   "main": "dist/index.js",
   "types": "index.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -214,7 +214,7 @@ describe("Compass Digital IDs", function()
             service: "menu",
             provider: "bamco",
             type: "item",
-            id: undefined
+            id: ""
         });
 
         done();
@@ -229,7 +229,7 @@ describe("Compass Digital IDs", function()
             service: "menu",
             provider: "bamco",
             type: "item",
-            id: undefined
+            id: ""
         });
 
         done();

--- a/test/test.js
+++ b/test/test.js
@@ -339,8 +339,9 @@ describe("Compass Digital IDs", function()
 
 	it("should check validity of id correctly", function(done)
 	{
+		this.timeout(5000);
 		const cdl_class = compassdigitalid.CompassDigitalId;
-		for(let i = 0; i < 100; i++)
+		for(let i = 0; i < 10000; i++)
 		{
 			const now = Date.now();
 			cdl_class.valid(

--- a/test/test.js
+++ b/test/test.js
@@ -340,7 +340,7 @@ describe("Compass Digital IDs", function()
 	it("should check validity of id correctly", function(done)
 	{
 		const cdl_class = compassdigitalid.CompassDigitalId;
-		for(let i = 0; i < 10000; i++)
+		for(let i = 0; i < 100; i++)
 		{
 			const now = Date.now();
 			cdl_class.valid(


### PR DESCRIPTION
The `id` property can currently be `undefined`. 

``` typescript
interface DecodedID {
  service: string;
  provider: string;
  type: string;
  id?: string;
}
```

None of the code I've seen actually checks if the `id` is `undefined` or not. I've also never seen a `DecodedID` where the `id` property is `undefined`. In fact, none of the ad-hoc declarations of `DecodedID` in specific repos even mark the `id` field as optional.

https://github.com/compassdigital/compassdigital.service.kds/blob/dd73d31120ccc81bfdda0fb5fe2e995e5bdbfc99/src/kds/interface/model.ts#L56-L61

I propose we change the logic to use an empty string (instead of `undefined`) when the id is omitted and change the interface to match the way it's already being used.

``` typescript
interface DecodedID {
  service: string;
  provider: string;
  type: string;
  id: string;
}
```


